### PR TITLE
Changed SQLAlchemy adapter name

### DIFF
--- a/flask-sqlalchemy/requirements.txt
+++ b/flask-sqlalchemy/requirements.txt
@@ -1,2 +1,2 @@
 flask-sqlalchemy
-cockroachdb
+sqlalchemy-cockroachdb


### PR DESCRIPTION
The CRDB SQLAlchemy package name has been changed to [`sqlalchemy-cockroachdb`](https://pypi.org/project/sqlalchemy-cockroachdb/).